### PR TITLE
Item file sending

### DIFF
--- a/parlay/items/parlay_standard.py
+++ b/parlay/items/parlay_standard.py
@@ -14,6 +14,9 @@ import re
 import inspect
 import Queue
 
+FILE_CAP_SIZE = 400
+SIZE_STEP = 1024
+
 
 class ParlayStandardItem(ThreadedItem):
     """
@@ -143,9 +146,9 @@ class ParlayStandardItem(ThreadedItem):
         """
         file_stats = os.stat(filename)
 
-        size_mb = (int(file_stats.st_size) // 1024) // 1024
+        size_mb = (int(file_stats.st_size) // SIZE_STEP) // SIZE_STEP
 
-        if size_mb > 400:
+        if size_mb > FILE_CAP_SIZE:
             raise IOError("File is too big! Please ensure the file is less than 400 MB and try again.")
 
 

--- a/parlay/items/parlay_standard.py
+++ b/parlay/items/parlay_standard.py
@@ -123,7 +123,13 @@ class ParlayStandardItem(ThreadedItem):
 
     def send_file(self, filename, receiver=None):
         """
-        send file contents as an event message to a receiver
+        send file contents as an event message (EVENT is ParlaySendFileEvent) to a receiver
+
+        :param filename: path to file that needs to be sent
+        :type filename: str
+        :param receiver: ID that the file needs to be sent to. by default, the receiver is None meaning
+          the file sending event should be broadcast. If not broadcast this will generally be "UI"
+        :type receiver: str
 
         the item will send an event message.  The contents will be formatted
         in the following way:

--- a/parlay/items/parlay_standard.py
+++ b/parlay/items/parlay_standard.py
@@ -14,8 +14,9 @@ import re
 import inspect
 import Queue
 
-FILE_CAP_SIZE = 400
-SIZE_STEP = 1024
+FILE_CAP_SIZE = 400  # megabytes
+FILE_CAP_UNITS = "MB"
+SIZE_STEP = 1024  # bytes per megabyte
 
 
 class ParlayStandardItem(ThreadedItem):
@@ -149,7 +150,7 @@ class ParlayStandardItem(ThreadedItem):
         size_mb = (int(file_stats.st_size) // SIZE_STEP) // SIZE_STEP
 
         if size_mb > FILE_CAP_SIZE:
-            raise IOError("File is too big! Please ensure the file is less than 400 MB and try again.")
+            raise IOError(" ".join(["File is too big! Please ensure the file is less than", str(FILE_CAP_SIZE), FILE_CAP_UNITS, "and try again."]))
 
 
         with open(filename, "r") as file_to_send:

--- a/parlay/items/parlay_standard.py
+++ b/parlay/items/parlay_standard.py
@@ -121,6 +121,33 @@ class ParlayStandardItem(ThreadedItem):
 
         return discovery
 
+    def send_file(self, filename, receiver):
+        """
+        send file contents as an event message to a receiver
+
+        the item will send an event message.  The contents will be formatted
+        in the following way:
+
+        contents: {
+            "EVENT": "ParlaySendFileEvent"
+            "DESCRIPTION": [filename being sent as string],
+            "INFO": [contents of file as string]
+        }
+        """
+        with open(filename, "r") as file_to_send:
+            try:
+                # in the future handle files sizes that are larger than 4 GB
+                file_contents = file_to_send.read()
+            except IOError as e:
+                print e
+
+        contents = {"EVENT": "ParlaySendFileEvent",
+                    "DESCRIPTION": filename,
+                    "INFO": file_contents}
+
+        send_message(to=receiver, msg_type=MSG_TYPES.EVENT, contents=contents)
+
+
     def send_message(self, to, from_=None, contents=None, tx_type=TX_TYPES.DIRECT, msg_type=MSG_TYPES.DATA, msg_id=None,
                      msg_status=MSG_STATUS.OK, response_req=False, extra_topics=None):
         """

--- a/parlay/items/parlay_standard.py
+++ b/parlay/items/parlay_standard.py
@@ -9,6 +9,7 @@ from twisted.internet.task import LoopingCall
 from parlay.items.threaded_item import ITEM_PROXIES, ThreadedItem
 from parlay.items.base import INPUT_TYPES, MSG_STATUS, MSG_TYPES, TX_TYPES, INPUT_TYPE_DISCOVERY_LOOKUP, \
     INPUT_TYPE_CONVERTER_LOOKUP
+import os
 import re
 import inspect
 import Queue
@@ -140,6 +141,14 @@ class ParlayStandardItem(ThreadedItem):
             "INFO": [contents of file as string]
         }
         """
+        file_stats = os.stat(filename)
+
+        size_mb = (int(file_stats.st_size) // 1024) // 1024
+
+        if size_mb > 400:
+            raise IOError("File is too big! Please ensure the file is less than 400 MB and try again.")
+
+
         with open(filename, "r") as file_to_send:
             try:
                 file_contents = file_to_send.read()


### PR DESCRIPTION
Added the ability for items to send files either by command or request.


This adds the method to ParlayItem self.send_file() which takes a filename and a receiver as the inputs.  The receiver argument can be left empty, specifying that the file should be announced as a broadcast message.

Also changes the send_message method to allow sending of broadcast messages, which it did not completely allow before.