### PR TITLE
Added optional "ui_caching" parameter to Broker.start()

### DIFF
--- a/parlay/server/broker.py
+++ b/parlay/server/broker.py
@@ -89,7 +89,7 @@ class Broker(object):
 
     @staticmethod
     def start(mode=Modes.DEVELOPMENT, ssl_only=False, open_browser=True, http_port=8080, https_port=8081,
-              websocket_port=8085, secure_websocket_port=8086, ui_path=None, log_level=logging.DEBUG):
+              websocket_port=8085, secure_websocket_port=8086, ui_path=None, log_level=logging.DEBUG, ui_caching=False):
         """
         Run the default Broker implementation.
         This call will not return.
@@ -109,7 +109,8 @@ class Broker(object):
             logger = LevelFileLogObserver(level=logging.ERROR)
             addObserver(logger.emit)
 
-        return broker.run(mode=mode, ssl_only=ssl_only, open_browser=open_browser, ui_path=ui_path)
+        return broker.run(mode=mode, ssl_only=ssl_only, open_browser=open_browser,
+                          ui_path=ui_path, ui_caching=ui_caching)
 
     @staticmethod
     def start_for_test():
@@ -284,8 +285,8 @@ class Broker(object):
         for k in root_list:
             if k is not None:  # special key for listener list
                 for v in root_list[k]:
-                        # call it again
-                        self.unsubscribe_all(owner, root_list[k][v])
+                    # call it again
+                    self.unsubscribe_all(owner, root_list[k][v])
 
     @classmethod
     def call_on_start(cls, func):
@@ -553,7 +554,7 @@ class Broker(object):
         except:
             return "UNKNOWN"
 
-    def run(self, mode=Modes.DEVELOPMENT, ssl_only=False, use_ssl=False, open_browser=True, ui_path=None):
+    def run(self, mode=Modes.DEVELOPMENT, ssl_only=False, use_ssl=False, open_browser=True, ui_path=None, ui_caching=False):
         """
         Start up and run the broker. This method call with not return
         """
@@ -584,6 +585,17 @@ class Broker(object):
             root = static.File(PARLAY_PATH + "/ui/dist")
             root.putChild("docs", static.File(PARLAY_PATH + "/docs/_build/html"))
 
+        # overloading twisted.server.Site.getResourceFor to add HTTP headers for setting browser cache
+        class Site(server.Site):
+            def getResourceFor(self, request):
+                if not ui_caching:
+                    cache_strategy = "no-store, must-revalidate"
+                else:
+                    freshness_time_secs = 3600 # content younger than 1 hour is considered fresh
+                    cache_strategy = "max-age={}".format(freshness_time_secs)
+                request.setHeader("Cache-Control", cache_strategy)
+                return server.Site.getResourceFor(self, request)
+
         # ssl websocket
         if use_ssl:
             try:
@@ -595,7 +607,7 @@ class Broker(object):
                 factory.setProtocolOptions()
                 listenWS(factory, ssl_context_factory, interface=interface)
                 root.contentTypes['.crt'] = 'application/x-x509-ca-cert'
-                self.reactor.listenSSL(self.https_port, server.Site(root), ssl_context_factory, interface=interface)
+                self.reactor.listenSSL(self.https_port, Site(root), ssl_context_factory, interface=interface)
 
             except ImportError:
                 print "WARNING: PyOpenSSL is *not* installed. Parlay cannot host HTTPS or WSS without PyOpenSSL"
@@ -611,8 +623,7 @@ class Broker(object):
             self.reactor.listenTCP(self.websocket_port, factory, interface=interface)
 
             # http server
-            site = server.Site(root)
-            self.reactor.listenTCP(self.http_port, site, interface=interface)
+            self.reactor.listenTCP(self.http_port, Site(root), interface=interface)
             if open_browser:
                 # give the reactor some time to init before opening the browser
                 self.reactor.callLater(.5, lambda: webbrowser.open_new_tab("http://localhost:"+str(self.http_port)))

--- a/parlay/server/http_server.py
+++ b/parlay/server/http_server.py
@@ -1,0 +1,22 @@
+from twisted.web import server
+
+
+FRESHNESS_TIME_SECS = 3600 # content younger than 1 hour is considered fresh
+
+
+class CacheControlledSite(server.Site):
+    """
+    Overloading twisted.server.Site to add HTTP headers for enabling/disabling browser cache
+    """
+    def __init__(self, ui_caching, resource, requestFactory=None, *args, **kwargs):
+        self._ui_caching = ui_caching
+        server.Site.__init__(self, resource, requestFactory, *args, **kwargs)
+
+    def getResourceFor(self, request):
+        if not self._ui_caching:
+            cache_strategy = "no-store, must-revalidate"
+        else:
+            cache_strategy = "max-age={}".format(FRESHNESS_TIME_SECS)
+
+        request.setHeader("cache-control", cache_strategy)
+        return server.Site.getResourceFor(self, request)

--- a/parlay/test/test_server_broker.py
+++ b/parlay/test/test_server_broker.py
@@ -46,7 +46,7 @@ class CacheControlledSiteTest(unittest.TestCase):
         request.prepath = [b""]
         request.postpath = [b""]
         site.getResourceFor(request)
-        assert(request.responseHeaders.getRawHeaders("cache-control") == ["no-store, must-revalidate"])
+        self.assertTrue(request.responseHeaders.getRawHeaders("cache-control") == ["no-store, must-revalidate"])
 
     def testUICaching(self):
         ui_caching = True
@@ -55,4 +55,4 @@ class CacheControlledSiteTest(unittest.TestCase):
         request.prepath = [b""]
         request.postpath = [b""]
         site.getResourceFor(request)
-        assert(request.responseHeaders.getRawHeaders("cache-control") == ["max-age={}".format(FRESHNESS_TIME_SECS)])
+        self.assertTrue(request.responseHeaders.getRawHeaders("cache-control") == ["max-age={}".format(FRESHNESS_TIME_SECS)])

--- a/parlay/test/test_server_broker.py
+++ b/parlay/test/test_server_broker.py
@@ -1,6 +1,11 @@
 from twisted.trial import unittest
 from twisted.internet import defer
-from parlay.server.broker import Broker
+from twisted.web import static, server
+from twisted.web.test.requesthelper import DummyChannel
+
+from parlay.server.broker import Broker, PARLAY_PATH
+from parlay.server.http_server import CacheControlledSite, FRESHNESS_TIME_SECS
+
 
 class BrokerPubSubTests(unittest.TestCase):
 
@@ -25,7 +30,29 @@ class BrokerPubSubTests(unittest.TestCase):
         self._broker.publish({"TOPICS": {"simple_unit_test": True}, "CONTENTS": {}})
         self.assertTrue(not sub_called.called)
 
-
     def tearDown(self):
         # always use self as the owner of any subscriptions so that this single call will clean it up
         self._broker.unsubscribe_all(self)
+
+
+class CacheControlledSiteTest(unittest.TestCase):
+    def setUp(self):
+        self._resource = static.File(PARLAY_PATH + "/ui/dist")
+
+    def testNoUICaching(self):
+        ui_caching = False
+        site = CacheControlledSite(ui_caching, self._resource)
+        request = server.Request(DummyChannel(), False)
+        request.prepath = [b""]
+        request.postpath = [b""]
+        site.getResourceFor(request)
+        assert(request.responseHeaders.getRawHeaders("cache-control") == ["no-store, must-revalidate"])
+
+    def testUICaching(self):
+        ui_caching = True
+        site = CacheControlledSite(ui_caching, self._resource)
+        request = server.Request(DummyChannel(), False)
+        request.prepath = [b""]
+        request.postpath = [b""]
+        site.getResourceFor(request)
+        assert(request.responseHeaders.getRawHeaders("cache-control") == ["max-age={}".format(FRESHNESS_TIME_SECS)])


### PR DESCRIPTION
Controls whether the browser should cache the Parlay UI. If `ui_caching` is set to true, the UI shall remain cached for up to 1 hour before becoming stale. If false, the UI shall never be cached.