### PR TITLE
PCOM: added support for auto connecting to USBs. 

### DIFF
--- a/parlay/protocols/pcom/pcom_serial.py
+++ b/parlay/protocols/pcom/pcom_serial.py
@@ -125,16 +125,27 @@ class PCOMSerial(BaseProtocol, LineReceiver):
     INVALID_SUBSYSTEM_ID = 0xFF
 
     @classmethod
-    def open(cls, adapter, port, discovery_file=None):
+    def open(cls, adapter, port=None, discovery_file=None):
         """
         :param cls: The class object
         :param adapter: current adapter instance used to interface with broker
-        :param port: the serial port device to use.
+        :param port: the serial port device to use. Leave this parameter empty if autoconnect is desired.
         :return: returns the instantiated protocol object
         '"""
 
         # Make sure port is not a list
         port = port[0] if isinstance(port, list) else port
+
+        if not port:
+            # If our port filter did not return only 1 available port, we cannot automatically connect.
+            # Raise exception and tell user to specify port manually.
+            default_args = cls.get_open_params_defaults()
+            if len(default_args['port']) != 1:
+                raise Exception('No port provided and filtered port list contained multiple entries: '
+                                '{}'.format(default_args['port']))
+
+            port = default_args['port'][0]
+
         protocol = PCOMSerial(adapter, port)
         protocol.discovery_file = None
         protocol._open_port()


### PR DESCRIPTION
Leave port parameter blank to use auto-detection. This works by running a filter on the available USB port connections. If only one valid connection is found PCOM will automatically connect to it. If any number other than 1 (0 or >1) are found PCOM will throw an exception telling the user to specify the port manually. 

Example:

Auto:
open_protocol("PCOMSerial")

Manual:
open_protocol("PCOMSerial", "/dev/"tty.usbmodem11124") 

In the UI you can leave the port option blank as well.