### PR TITLE
Add ability for Parlay Python scripts to call callLater function

### DIFF
--- a/parlay/scripts.py
+++ b/parlay/scripts.py
@@ -14,6 +14,7 @@ shutdown_broker = lambda: scripting_setup.script.shutdown_broker()
 open = lambda protocol_name, **kwargs: scripting_setup.script.open(protocol_name, **kwargs)
 open_protocol = open
 close_protocol = lambda protocol_id: scripting_setup.script.close_protocol(protocol_id)
+call_later = lambda seconds, func, *args, **kwargs: scripting_setup.script.call_later(seconds, func, *args, **kwargs)
 
 # send_parlay_command = lambda *args, **kwargs: scripting_setup.script.
 

--- a/parlay/utils/parlay_script.py
+++ b/parlay/utils/parlay_script.py
@@ -9,6 +9,7 @@ import traceback
 from parlay.items.threaded_item import ThreadedItem, ITEM_PROXIES, ListenerStatus
 from autobahn.twisted.websocket import WebSocketClientFactory
 from parlay.protocols.websocket import WebsocketClientAdapter, WebsocketClientAdapterFactory
+from parlay.server.broker import run_in_broker
 
 DEFAULT_ENGINE_WEBSOCKET_PORT = 8085
 
@@ -39,6 +40,19 @@ class ParlayScript(ThreadedItem):
     def kill(self):
         """ Kill the current script """
         self.cleanup()
+
+    @run_in_broker
+    def call_later(self, secs, fn, *args, **kwargs):
+        """
+        Calls function <fn> after <secs> seconds have passed.
+
+        :param secs: seconds to wait before calling function <fn>
+        :param fn: function to call
+        :param args: positional arguments that should be passed to <fn>
+        :param kwargs: keyword arguments that should be passed to <fn>
+        :return:
+        """
+        return self._reactor.callLater(secs, fn, *args, **kwargs)
 
     def cleanup(self, *args):
         """


### PR DESCRIPTION
parlay/utils: added ability for scripts to use the call_later function. This function is called in the reactor thread using the @run_in_broker decorator.