### PR TITLE
Add New Property Specs

### DIFF
--- a/parlay/docs/src/specs/parlay_standard_item_comms_spec.rst
+++ b/parlay/docs/src/specs/parlay_standard_item_comms_spec.rst
@@ -231,13 +231,20 @@ Property Object Format
 | "PROPERTY_NAME" | NO          | The property name (Defaults to ID)            |
 +-----------------+-------------+-----------------------------------------------+
 | "INPUT"         | Yes         | "NUMBER", "STRING", "NUMBERS", "STRINGS",     |
-|                 |             | "OBJECT", "ARRAY", "DROPDOWN"                 |
+|                 |             | "ARRAY", "BOOLEAN",                           |
+|                 |             | ["NUMBER(S)" || "STRING(S)" || "BOOLEAN"]     |
+|                 |             |                                               |
+|                 |             | Specifiying an array of types is used for     |
+|                 |             | specificying struct type order                |
 +-----------------+-------------+-----------------------------------------------+
 | "READ\_ONLY"    | No          | Boolean, whether the property is read only,   |
 |                 |             | defaults to false                             |
 +-----------------+-------------+-----------------------------------------------+
 | "WRITE\_ONLY"   | No          | Boolean, whether the property is write only,  |
 |                 |             | defaults to false                             |
++-----------------+-------------+-----------------------------------------------+
+| "STREAMABLE"    | No          | Boolean, whether the property can be streamed,|
+|                 |             | defaults to true                              |
 +-----------------+-------------+-----------------------------------------------+
 
 DataStream Object Format
@@ -266,7 +273,8 @@ Field Object format
 |                         |             | field >                                       |
 +-------------------------+-------------+-----------------------------------------------+
 | "INPUT"                 | Yes         | "NUMBER", "STRING", "NUMBERS", "STRINGS",     |
-|                         |             | "OBJECT", "ARRAY", "DROPDOWN"                 |
+|                         |             | "ARRAY", "DROPDOWN", "BOOLEAN"                |
+|                         |             | ["NUMBER(S)" || "STRING(S)" || "BOOLEAN"]     |
 +-------------------------+-------------+-----------------------------------------------+
 | "REQUIRED"              | No          | If true, require the user fill out before     |
 |                         |             | sending command                               |

--- a/parlay/items/base.py
+++ b/parlay/items/base.py
@@ -41,8 +41,6 @@ def _convert_to_boolean(bool_arg):
     # This check will also work for booleans since they inherit from the Number base class.
     elif isinstance(bool_arg, Number):
         return bool(bool_arg)
-    elif isinstance(bool_arg, bool):
-        return bool_arg
     else:
         raise TypeError("Could not convert argument to boolean")
 

--- a/parlay/items/base.py
+++ b/parlay/items/base.py
@@ -11,12 +11,13 @@ class INPUT_TYPES(object):
     OBJECT = "OBJECT"
     ARRAY = "ARRAY"
     DROPDOWN = "DROPDOWN"
+    BOOLEAN = "BOOLEAN"
 
 # lookup table for arg discovery
 INPUT_TYPE_DISCOVERY_LOOKUP = {'str': INPUT_TYPES.STRING, 'string': INPUT_TYPES.STRING, 'char': INPUT_TYPES.STRING,
                                'int': INPUT_TYPES.NUMBER, 'float': INPUT_TYPES.NUMBER, 'double': INPUT_TYPES.NUMBER,
                                'short': INPUT_TYPES.NUMBER, 'long': INPUT_TYPES.NUMBER, 'list': INPUT_TYPES.ARRAY,
-                               'bool': INPUT_TYPES.STRING}
+                               'bool': INPUT_TYPES.BOOLEAN}
 
 # dynamically add list types
 for k in INPUT_TYPE_DISCOVERY_LOOKUP.keys():
@@ -40,6 +41,8 @@ def _convert_to_boolean(bool_arg):
     # This check will also work for booleans since they inherit from the Number base class.
     elif isinstance(bool_arg, Number):
         return bool(bool_arg)
+    elif isinstance(bool_arg, bool):
+        return bool_arg
     else:
         raise TypeError("Could not convert argument to boolean")
 

--- a/parlay/protocols/pcom/pcom_serial.py
+++ b/parlay/protocols/pcom/pcom_serial.py
@@ -31,7 +31,8 @@ import json
 # Constants used in converting format chars to
 # Parlay input types
 PCOM_SERIAL_NUMBER_INPUT_CHARS = "BbHhIiQqfd"
-PCOM_SERIAL_STRING_INPUT_CHARS = "?csx"
+PCOM_SERIAL_STRING_INPUT_CHARS = "csx"
+PCOM_SERIAL_BOOL_INPUT_CHARS= "?"
 PCOM_SERIAL_ARRAY_INPUT_CHARS = '*'
 
 # Store a map of Item IDs -> Command ID -> Command Objects
@@ -1187,6 +1188,8 @@ class PCOMSerial(BaseProtocol, LineReceiver):
             return INPUT_TYPES.ARRAY
         elif format_char in PCOM_SERIAL_STRING_INPUT_CHARS:
             return INPUT_TYPES.STRING
+        elif format_char in PCOM_SERIAL_BOOL_INPUT_CHARS:
+            return INPUT_TYPES.BOOLEAN
         else:
             logger.warn("Invalid format character {0} defaulting to INPUT TYPE STRING".format(format_char))
 


### PR DESCRIPTION
Adds Boolean type to properties and command fields

Adds documentation for INPUT types as arrays, useful for embedded devices reporting struct formats during discovery

Should resolve issues: PARLAY-483 and PARLAY-482