### PR TITLE
Updated requirement for pyOpenSSL due to Twisted TLS dependency on Ma…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ ipaddress>=1.0.16
 pyasn1>=0.1.9
 pyasn1-modules>=0.0.8
 pycparser>=2.14
+pyOpenSSL>=17.5.0
 pyserial>=3.4
 service-identity>=14.0.0
 six>=1.10.0

--- a/requirements_secure.txt
+++ b/requirements_secure.txt
@@ -1,4 +1,3 @@
 #Additional requirements for a secure version of parlay (SSL enabled)
 cryptography>=1.2.1
-pyOpenSSL>=0.15.1
 cffi>=1.5.0

--- a/setup.py
+++ b/setup.py
@@ -66,10 +66,11 @@ setup(
     package_data={"parlay": package_data_files},
     install_requires=["Twisted >=17.9.0",
                       "autobahn >=0.9.0",
-                      "pyserial >= 3.4.0"],
+                      "pyserial >= 3.4.0",
+                      "pyOpenSSL >= 17.5.0"
+                      ],
     extras_require={
         "secure": ["cryptography>=1.2.1",
-                   "pyOpenSSL>=0.15.1",
                    "cffi>=1.5.0",
                    "service-identity >=14.0.0",
                    "requests",


### PR DESCRIPTION
…cOS and Linux.

Fixes Twisted-17.0.0 dependency on TLS library from pyOpenSSL. Parlay produces the following exception on Mac/Linux when the requirement is not met.

![screen shot 2018-01-08 at 11 37 41 am](https://user-images.githubusercontent.com/7563021/34698138-6f7eff12-f48b-11e7-98db-9cf3c2a7f27a.png)
